### PR TITLE
fix to save metadata before data

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ StreamingCache.prototype.setData = function (key, data) {
 
     var c = {};
     c.data = data;
+    c.metadata = self.getMetadata(key) || {};
+
     c.status = STATUS_DONE;
     self.cache.set(key, c);
     return this;
@@ -159,7 +161,9 @@ StreamingCache.prototype.set = function (key) {
     var self = this;
     checkKey(key);
 
-    self.cache.set(key, {status : STATUS_PENDING, metadata: {}});
+    var metadata = self.getMetadata(key) || {};
+
+    self.cache.set(key, { status : STATUS_PENDING, metadata: metadata});
     emitters[key] = new EventEmitter();
     emitters[key].setMaxListeners(250);
     emitters[key]._buffer = [];
@@ -184,7 +188,7 @@ StreamingCache.prototype.set = function (key) {
         var c = self.cache.get(key);
         var buffer = Buffer.concat(emitters[key]._buffer)
         c.metadata = c.metadata || {};
-        c.metadata.length = buffer.length;
+        c.metadata.length = buffer.toString().length;
         c.metadata.byteLength = buffer.byteLength;
         c.data = buffer;
         c.status = STATUS_DONE;

--- a/spec/streamingCacheSpec.js
+++ b/spec/streamingCacheSpec.js
@@ -8,6 +8,7 @@ var cache = new StreamingCache();
 describe('streaming cache', function () {
     var s;
     beforeEach(function () {
+        cache = new StreamingCache()
         s = cache.set('a');
     })
 
@@ -82,13 +83,27 @@ describe('streaming cache', function () {
     });
 
     it('should handle setmetadata', function () {
-        cache.cache.set('abc', {data: 'test'});
+        cache.setMetadata('abc', {a:'c'});
+        cache.setData('abc', 'test');
         expect(cache.setMetadata).toThrow();
-        cache.setMetadata('abc', 1234);
         expect(cache.cache.get('abc').data).toEqual('test');
-        expect(cache.getMetadata('abc')).toEqual(1234);
+        expect(cache.getMetadata('abc').a).toEqual('c');
     });
 
+    it('should save the length to metadata', function (done) {
+        cache.setMetadata('abc', {a:'b'});
+        var s = cache.set('abc');
+        s.write('a');
+        s.write('b');
+        s.end('');
+
+        setTimeout(function(){
+            expect(cache.cache.get('abc').data.toString()).toEqual('ab');
+            expect(cache.getMetadata('abc').a).toEqual('b');
+            expect(cache.getMetadata('abc').length).toEqual(2);
+            done();
+        }, 10)
+    });
     it('should handle getmetadata', function () {
         cache.cache.set('abc', {data: 1, metaData: 'bbb'});
         expect(cache.getMetadata).toThrow();


### PR DESCRIPTION
* metadata will not be removed by calling  setData(key) or set(key)
* metadata will be removed by del(key)
* setMetadata(key) will cause an exists(key) to return true

*hardened tests.