### PR TITLE
short cache timeouts can cause error

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,42 +1,23 @@
 'use strict';
-
 var Cache = require('../index.js');
-
-var cache = new Cache();
-
+var cache = new Cache({max: 5, maxAge: 15});
 var fs = require('fs');
-
-// var readstream = fs.createReadStream('readme.md');
-// var writestream = fs.createWriteStream('test.md');
-var writestream2 = fs.createWriteStream('test2.txt');
-
-// readstream.pipe(cache.put('a'));
-// readstream.pipe(writestream);
-// readstream.pipe(process.stderr);
-
-// setTimeout(function(){
-// 	writestream2.write('written from cache\n\n');
-// 	cache.get('a').pipe(writestream2);
-// }, 200);
-
-// setTimeout(function(){}, 2000);
-
-//process.stdin.pipe(cache.put('a'));
-
 var cnt = 0;
-var s = cache.set('a')
+var s = cache.set('a');
 var intervalId = setInterval(function () {
-    if (cnt >= 5) {
-        // console.log('cnt', cnt)
-        clearInterval(intervalId)
-        cache.get('a').pipe(process.stdout);
+    if (cnt >= 50) {
+        clearInterval(intervalId);
+        console.log('');
+        //cache.get('a').pipe(process.stdout);
         s.end();
     } else {
-        s.write(cnt + ' hello', function () {})
+        s.write(cnt + ' hello\n');
         cnt++;
     }
-}, 1000)
+}, 100);
 
-//setTimeout(function () {
+s.pipe(process.stdout);
 cache.get('a').pipe(process.stdout);
-// }, 5000);
+
+
+    

--- a/examples/example.js
+++ b/examples/example.js
@@ -7,8 +7,6 @@ var s = cache.set('a');
 var intervalId = setInterval(function () {
     if (cnt >= 50) {
         clearInterval(intervalId);
-        console.log('');
-        //cache.get('a').pipe(process.stdout);
         s.end();
     } else {
         s.write(cnt + ' hello\n');

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var lruOptions = {
 };
 
 var StreamingCache = function StreamingCache(options) {
+    options.length = lruOptions.length;
     this.cache = LRU(options);
     Object.defineProperty(this, 'length', {
         get: function () {
@@ -73,6 +74,7 @@ StreamingCache.prototype.getData = function (key, cb) {
         return;
     }
 }
+
 StreamingCache.prototype.setMetadata = function (key, metadata) {
     checkKey(key);
 
@@ -169,23 +171,22 @@ StreamingCache.prototype.set = function (key) {
     var stream = new Streams.Duplex()
     stream._read = function () {
         var chunk = chunks.shift();
-        if(!chunk){
+        if (!chunk) {
             this.needRead = true;
         }
-        else{
-           this.push(chunk);
-           this.needRead = false;
+        else {
+            this.push(chunk);
+            this.needRead = false;
         }
     }
     stream._write =  function (chunk, encoding, next) {
         emitters[key]._buffer.push(chunk);
         emitters[key].emit('data', chunk);
-        if(this.needRead){
+        if (this.needRead) {
             this.push(chunk);
         }
-        else{
+        else {
             chunks.push(chunk);
-
         }
         next(null, chunk);
     }
@@ -200,15 +201,19 @@ StreamingCache.prototype.set = function (key) {
         delete emitters[key];
     });
     stream.on('finish', function () {
-        if(this.needRead){
+        if (this.needRead) {
             this.push(null);
         }
-        else{
-        chunks.push(null);
+        else {
+            chunks.push(null);
         }
         var c = self.cache.get(key);
-
-        var buffer = Buffer.concat(emitters[key]._buffer)
+        if (!c) {
+            emitters[key].emit('end', Buffer.concat(emitters[key]._buffer));
+            delete emitters[key];
+            return;
+        }
+        var buffer = Buffer.concat(emitters[key]._buffer);
         c.metadata = c.metadata || {};
         c.metadata.length = buffer.toString().length;
         c.metadata.byteLength = buffer.byteLength;

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var lruOptions = {
 };
 
 var StreamingCache = function StreamingCache(options) {
+    options = options || {};
     options.length = lruOptions.length;
     this.cache = LRU(options);
     Object.defineProperty(this, 'length', {
@@ -208,6 +209,7 @@ StreamingCache.prototype.set = function (key) {
             chunks.push(null);
         }
         var c = self.cache.get(key);
+        chunks = null;
         if (!c) {
             emitters[key].emit('end', Buffer.concat(emitters[key]._buffer));
             delete emitters[key];

--- a/spec/streamingCacheSpec.js
+++ b/spec/streamingCacheSpec.js
@@ -74,7 +74,7 @@ describe('streaming cache', function () {
 
     it('should handle getData when data is missing', function (done) {
         expect(cache.getData).toThrow();
-        expect(function() { cache.getData('c') }).toThrow();
+        expect(function () { cache.getData('c') }).toThrow();
         expect(cache.getData('c', function (err, data) {
             expect(data).toEqual(undefined);
             expect(err).toEqual('cache miss');
@@ -83,7 +83,7 @@ describe('streaming cache', function () {
     });
 
     it('should handle setmetadata', function () {
-        cache.setMetadata('abc', {a:'c'});
+        cache.setMetadata('abc', {a: 'c'});
         cache.setData('abc', 'test');
         expect(cache.setMetadata).toThrow();
         expect(cache.cache.get('abc').data).toEqual('test');
@@ -91,13 +91,13 @@ describe('streaming cache', function () {
     });
 
     it('should save the length to metadata', function (done) {
-        cache.setMetadata('abc', {a:'b'});
+        cache.setMetadata('abc', {a: 'b'});
         var s = cache.set('abc');
         s.write('a');
         s.write('b');
         s.end('');
 
-        setTimeout(function(){
+        setTimeout(function () {
             expect(cache.cache.get('abc').data.toString()).toEqual('ab');
             expect(cache.getMetadata('abc').a).toEqual('b');
             expect(cache.getMetadata('abc').length).toEqual(2);
@@ -116,7 +116,7 @@ describe('streaming cache', function () {
         expect(cache.getMetadata('abc')).toEqual({});
     });
 
-    it('should reset the cache when called', function() {
+    it('should reset the cache when called', function () {
         cache.setData('aaa', 'value');
         cache.reset();
         expect(cache.exists('aaa')).toEqual(false);
@@ -136,5 +136,24 @@ describe('streaming cache', function () {
         cache.setData('aaa', 'value');
         expect(cache.exists('aaa')).toEqual(true);
     });
+});
 
+describe('streaming cache short timeout', function () {
+    var s;
+    beforeEach(function () {
+        cache = new StreamingCache({maxAge: 100})
+        s = cache.set('b');
+    });
+    it('Writing to stream should set data', function (done) {
+        s.write('a');
+        s.write('b');
+        s.end(null);
+        setTimeout(function () {
+            expect(s.read().toString() + s.read().toString()).toEqual('ab')
+            cache.getData('b', function (err, data) {
+                expect(data.toString()).toEqual(null)
+                done();
+            });
+        }, 130);
+    });
 });


### PR DESCRIPTION
when the timeout is set shorter than the time it takes for the cache
stream to finish, an error will be thrown. This fix will serve the data
without an error.