### PR TITLE
Fix concurrent requests (when using flowing stream)

### DIFF
--- a/lib/readStream.js
+++ b/lib/readStream.js
@@ -37,8 +37,11 @@ ReadStream.prototype._push = function (size) {
     size = Math.min(size, this._object.length - this._offset);
 
     if (this._offset < this._object.length) {
-        this.push(this._object.slice(this._offset, this._offset + size));
-        this._offset += size ;
+        var currentOffset = this._offset;
+        var nextOffset = this._offset + size;
+        this._offset = nextOffset;
+
+        this.push(this._object.slice(currentOffset, nextOffset));
     }
 };
 

--- a/lib/readStream.js
+++ b/lib/readStream.js
@@ -41,7 +41,12 @@ ReadStream.prototype._push = function (size) {
         var nextOffset = this._offset + size;
         this._offset = nextOffset;
 
-        this.push(this._object.slice(currentOffset, nextOffset));
+        try {
+            this.push(this._object.slice(currentOffset, nextOffset));
+        }
+        catch (err) {
+            this.emit('error', err)
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming-cache",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Cache and replay NodeJS streams",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming-cache",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Cache and replay NodeJS streams",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming-cache",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Cache and replay NodeJS streams",
   "main": "index.js",
   "scripts": {

--- a/spec/readStreamSpec.js
+++ b/spec/readStreamSpec.js
@@ -57,4 +57,23 @@ describe('readstream spec', function () {
             done();
         }, 30);
     });
+
+    describe('with flowing stream', function () {
+        beforeEach(function () {
+            // Adding a 'data' event handler changes
+            // a stream from "paused" mode to "flowing" mode
+            readStream.on('data', () => null);
+        })
+
+        it('should be able to set a buffer', function () {
+            var len = 1;
+            expect(readStream.read(2)).toEqual(null);
+            readStream.setBuffer(new Buffer(len));
+
+            expect(readStream.complete).toBe(true);
+            expect(readStream._offset).toBe(len);
+            expect(readStream._object.length).toBe(len);
+        });
+    });
+
 });


### PR DESCRIPTION
2 concurrent requests to a cold cache (via an Express HTTP server) cause the 2nd request to hang. Subsequent requests work fine. I couldn't reproduce it in this [server example](https://github.com/LaurentZuijdwijk/streaming-cache/blob/master/examples/server.js) (although I didn't try too hard) - but the attached unit test proves it... I think.

Here's a [Node v7.4.0](https://github.com/nodejs/node/blob/966e5cfb8169a35bf3a99d0272256b0976681a70/lib/_stream_readable.js) stacktrace

```
    at ReadStream._read (.../node_modules/streaming-cache/lib/readStream.js:46:15)
    at ReadStream.Readable.read (_stream_readable.js:348:10)
    at readableAddChunk (_stream_readable.js:177:18)
    at ReadStream.Readable.push (_stream_readable.js:134:10)
    at ReadStream._push
```

Where calling `Readable.push` calls `._read` (because it's a flowing stream) which calls `._push` which causes the function to end in a state where it never calls `.push(null)`
